### PR TITLE
test: table construct, autolink, and an open reference link mixed

### DIFF
--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -98,5 +98,11 @@ fn fuzz() -> Result<(), String> {
         "8-d: autolink literals after tabs (GH-18)"
     );
 
+    assert_eq!(
+        to_html_with_options("|\n\n|\n|\nwww.a[a.a|\n|\n", &Options::gfm()),
+        Ok("<p>|</p><p>|<br>|<br><a href=\"http://www.a%5Ba.a%7C\">www.a[a.a]</a><br>|</p>".into()),
+        "9: gfm: mix table, autolink, and open reference link"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
When a table construct, autolink, and an open reference link are mixed.

it causes a panic at
https://github.com/wooorm/markdown-rs/blob/b910e37bb387a62509a7fda26617e9870ed6d56f/src/subtokenize.rs#L211

with:

> thread 'fuzz' panicked at 'called `Option::unwrap()` on a `None` value