### PR TITLE
Fix `cargo fmt` errors

### DIFF
--- a/src/construct/gfm_autolink_literal.rs
+++ b/src/construct/gfm_autolink_literal.rs
@@ -334,7 +334,7 @@ pub fn www_prefix_inside(tokenizer: &mut Tokenizer) -> State {
 /// ```
 pub fn www_prefix_after(tokenizer: &mut Tokenizer) -> State {
     // If there is *anything*, we can link.
-    if tokenizer.current == None {
+    if tokenizer.current.is_none() {
         State::Nok
     } else {
         State::Ok

--- a/src/construct/gfm_task_list_item_check.rs
+++ b/src/construct/gfm_task_list_item_check.rs
@@ -61,7 +61,7 @@ pub fn start(tokenizer: &mut Tokenizer) -> State {
             .tokenize_state
             .document_at_first_paragraph_of_list_item
         && tokenizer.current == Some(b'[')
-        && tokenizer.previous == None
+        && tokenizer.previous.is_none()
     {
         tokenizer.enter(Name::GfmTaskListItemCheck);
         tokenizer.enter(Name::GfmTaskListItemMarker);
@@ -149,7 +149,7 @@ pub fn after(tokenizer: &mut Tokenizer) -> State {
 /// ```
 pub fn after_space_or_tab(tokenizer: &mut Tokenizer) -> State {
     // End of paragraph, after whitespace, after check, is not okay.
-    if tokenizer.current == None {
+    if tokenizer.current.is_none() {
         State::Nok
     } else {
         State::Ok

--- a/src/construct/mdx_esm.rs
+++ b/src/construct/mdx_esm.rs
@@ -216,7 +216,7 @@ fn parse_esm(tokenizer: &mut Tokenizer) -> State {
             State::Error(format!("{}:{}: {}", point.line, point.column, message))
         }
         MdxSignal::Eof(message) => {
-            if tokenizer.current == None {
+            if tokenizer.current.is_none() {
                 State::Error(format!(
                     "{}:{}: {}",
                     tokenizer.point.line, tokenizer.point.column, message

--- a/src/construct/partial_mdx_jsx.rs
+++ b/src/construct/partial_mdx_jsx.rs
@@ -1119,7 +1119,7 @@ fn crash(tokenizer: &Tokenizer, at: &str, expect: &str) -> State {
         "{}:{}: Unexpected {} {}, expected {}",
         tokenizer.point.line,
         tokenizer.point.column,
-        format_char_opt(if tokenizer.current == None {
+        format_char_opt(if tokenizer.current.is_none() {
             None
         } else {
             char_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)

--- a/src/mdast.rs
+++ b/src/mdast.rs
@@ -250,7 +250,7 @@ impl ToString for Node {
             | Node::Image(_)
             | Node::ImageReference(_)
             | Node::ThematicBreak(_)
-            | Node::Definition(_) => "".into(),
+            | Node::Definition(_) => String::new(),
         }
     }
 }

--- a/src/subtokenize.rs
+++ b/src/subtokenize.rs
@@ -96,7 +96,7 @@ pub fn subtokenize(
             debug_assert_eq!(event.kind, Kind::Enter);
 
             // No need to enter linked events again.
-            if link.previous == None
+            if link.previous.is_none()
                 && (filter.is_none() || &link.content == filter.as_ref().unwrap())
             {
                 // Index into `events` pointing to a chunk.
@@ -148,7 +148,7 @@ pub fn subtokenize(
                     let link_curr = enter.link.as_ref().expect("expected link");
                     debug_assert_eq!(enter.kind, Kind::Enter);
 
-                    if link_curr.previous != None {
+                    if link_curr.previous.is_some() {
                         tokenizer.define_skip(enter.point.clone());
                     }
 

--- a/src/to_html.rs
+++ b/src/to_html.rs
@@ -685,7 +685,7 @@ fn on_enter_paragraph(context: &mut CompileContext) {
 /// Handle [`Enter`][Kind::Enter]:[`Resource`][Name::Resource].
 fn on_enter_resource(context: &mut CompileContext) {
     context.buffer(); // We can have line endings in the resource, ignore them.
-    context.media_stack.last_mut().unwrap().destination = Some("".into());
+    context.media_stack.last_mut().unwrap().destination = Some(String::new());
 }
 
 /// Handle [`Enter`][Kind::Enter]:[`ResourceDestinationString`][Name::ResourceDestinationString].

--- a/src/to_mdast.rs
+++ b/src/to_mdast.rs
@@ -1751,7 +1751,7 @@ fn on_mismatch_error(
             if let Some(left) = left {
                 format!(" before the end of `{:?}`", left.name)
             } else {
-                "".into()
+                String::new()
             }
         ));
     }

--- a/src/util/sanitize_uri.rs
+++ b/src/util/sanitize_uri.rs
@@ -24,7 +24,7 @@ use alloc::{format, string::String, vec::Vec};
 /// *   [`micromark-util-sanitize-uri` in `micromark`](https://github.com/micromark/micromark/tree/main/packages/micromark-util-sanitize-uri)
 #[must_use]
 pub fn sanitize(value: &str) -> String {
-    encode(&*normalize(value), true)
+    encode(&normalize(value), true)
 }
 
 /// Make a value safe for injection as a URL, and check protocols.
@@ -71,7 +71,7 @@ pub fn sanitize_with_protocols(value: &str, protocols: &[&str]) -> String {
         // If it is a protocol, it should be allowed.
         let protocol = value[0..colon].to_lowercase();
         if !protocols.contains(&protocol.as_str()) {
-            return "".into();
+            return String::new();
         }
     }
 


### PR DESCRIPTION
Fix the errors and warnings from the lint command: `cargo fmt --check && cargo clippy --examples --tests --benches`