### PR TITLE
build(cargo): allow to control reqwest tls backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,13 @@ homepage = "https://github.com/wooorm/markdown-rs"
 repository = "https://github.com/wooorm/markdown-rs"
 license = "MIT"
 keywords = ["commonmark", "markdown", "parse", "render", "tokenize"]
-categories = ["compilers", "encoding", "parser-implementations", "parsing", "text-processing"]
+categories = [
+  "compilers",
+  "encoding",
+  "parser-implementations",
+  "parsing",
+  "text-processing",
+]
 include = ["src/", "license"]
 
 [[bench]]
@@ -21,6 +27,19 @@ harness = false
 log = "0.4"
 unicode-id = { version = "0.3", features = ["no_std"] }
 
+[features]
+default = ["native-tls"]
+# Provides way to control which TLS backend is used.
+# This is helpful to support platform targets requires specific TLS backend -
+# If a upstream application have transitive deps to reqwest somewhere,
+# cargo tries to merge all of the features from reqwest and try to build unsupported
+# TLS backend for the specific platform. Fine grained control of TLS backend
+# allows to avoid this issue.
+#
+# Normally, you don't need to specify this feature as reqwest's default (native-tls)
+# is enabled by default.
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 env_logger = "0.10"
@@ -35,5 +54,5 @@ swc_core = { version = "0.43.30", features = [
 
 [build-dependencies]
 regex = "1"
-reqwest = "0.11"
+reqwest = { version = "0.11", default-features = false }
 tokio = { version = "1", features = ["full"] }

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,19 @@ async fn main() {
 }
 
 async fn commonmark() {
-    let url = "https://raw.githubusercontent.com/commonmark/commonmark-spec/0.30/spec.txt";
+    #[cfg(all(feature = "native-tls", feature = "rustls-tls"))]
+    {
+        panic!("`native-tls` and `rustls-tls` features are mutually exclusive");
+    }
+
+    let url = if cfg!(any(feature = "native-tls", feature = "rustls-tls")) {
+        "https://raw.githubusercontent.com/commonmark/commonmark-spec/0.30/spec.txt"
+    } else {
+        println!("cargo:warning={}","[Warning]: neither `native-tls` nor `default-tls` feature is enabled, using HTTP instead of HTTPS.");
+        println!("cargo:warning={}","           This means default feature for `native-tls` is turned off but corresponding feature is not enabled.");
+        "http://raw.githubusercontent.com/commonmark/commonmark-spec/0.30/spec.txt"
+    };
+
     let data_url = "commonmark-data.txt";
     let code_url = "tests/commonmark.rs";
 


### PR DESCRIPTION
This PR allows to control TLS backend for the dependency `reqwest`, while makes default (native-tls) as-is. Only if someone need to explicitly control they can disable default, then opt into specific.

`reqwest` is build-dependencies, so may seems it doesn't cause any problem: however, due to cargo creates lockfile & compiles it can actually brings some interesting challenges. 

```
// Cargo.toml: Application

[dependencies]
LibA = *

// Cargo.toml: LibA
[dependencies]
reqwest = {.., features = ["rustls-tls"]}
markdown = *

// Cargo.toml: markdown

[build-dependencies]
reqwest = * // default, native-tls is enabled
```

Now building `Application` generates a lockfile for it, and cargo _merges_ every feature for the dependencies into single like 

```
reqwest = {
...
features = ["rustls-tls", "native-tls"]
}
```

regardless of type of dependencies. There are target platforms require specific TLS backend only, now building `Application` fails on those platform.

I tried to make this change non-invasive as much. Default works exactly same as current, and only explicit opt-in would change its behavior. Also added cases for 1. for disabling tls entirely, attempt to use `http` with warning 2. specifying both tls fails build.
