### PR TITLE
Fix to add `features: 'derive'` for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ json = ["dep:serde", "dep:serde_json"]
 [dependencies]
 log = "0.4"
 unicode-id = { version = "0.3", features = ["no_std"] }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #44 

Sorry about that. Not sure why the compiler didn't complain about it. The fix can be verified by changing `markdown = "=1.0.0-alpha.6"` to `markdown = { git = "https://github.com/kyle-mccarthy/markdown-rs", branch = "fix/serde-attr" }` in a project.