### PR TITLE
Move `log` to optional dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["json"]
 json = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4", optional = true }
 unicode-id = { version = "0.3", features = ["no_std"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -13,7 +13,11 @@ use crate::parser::ParseState;
 use crate::resolve::{call as call_resolve, Name as ResolveName};
 use crate::state::{call, State};
 use crate::subtokenize::Subresult;
-use crate::util::{char::format_byte_opt, constant::TAB_SIZE, edit_map::EditMap};
+
+#[cfg(feature = "log")]
+use crate::util::char::format_byte_opt;
+
+use crate::util::{constant::TAB_SIZE, edit_map::EditMap};
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 
 /// Containers.
@@ -405,7 +409,10 @@ impl<'a> Tokenizer<'a> {
         move_point_back(self, &mut point);
 
         let info = (point.index, point.vs);
+
+        #[cfg(feature = "log")]
         log::debug!("position: define skip: {:?} -> ({:?})", point.line, info);
+
         let at = point.line - self.first_line;
 
         if at >= self.column_start.len() {
@@ -476,7 +483,10 @@ impl<'a> Tokenizer<'a> {
                     self.line_start = self.point.clone();
 
                     self.account_for_potential_skip();
+ 
+                    #[cfg(feature = "log")]
                     log::debug!("position: after eol: `{:?}`", self.point);
+
                 } else {
                     self.point.column += 1;
                 }
@@ -533,7 +543,9 @@ impl<'a> Tokenizer<'a> {
             move_point_back(self, &mut point);
         }
 
+        #[cfg(feature = "log")]
         log::debug!("exit:    `{:?}`", name);
+
         let event = Event {
             kind: Kind::Exit,
             name,
@@ -663,7 +675,9 @@ fn enter_impl(tokenizer: &mut Tokenizer, name: Name, link: Option<Link>) {
     let mut point = tokenizer.point.clone();
     move_point_back(tokenizer, &mut point);
 
+    #[cfg(feature = "log")]
     log::debug!("enter:   `{:?}`", name);
+
     tokenizer.stack.push(name.clone());
     tokenizer.events.push(Event {
         kind: Kind::Enter,
@@ -708,7 +722,9 @@ fn push_impl(
                         attempt.nok
                     };
 
+                    #[cfg(feature = "log")]
                     log::debug!("attempt: `{:?}` -> `{:?}`", state, next);
+
                     state = next;
                 } else {
                     break;
@@ -735,13 +751,18 @@ fn push_impl(
                             None
                         };
 
+                    #[cfg(feature = "log")]
                     log::debug!("feed:    {} to {:?}", format_byte_opt(byte), name);
+
                     tokenizer.expect(byte);
                     state = call(tokenizer, name);
                 };
             }
             State::Retry(name) => {
+
+                #[cfg(feature = "log")]
                 log::debug!("retry:   `{:?}`", name);
+
                 state = call(tokenizer, name);
             }
         }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -483,10 +483,9 @@ impl<'a> Tokenizer<'a> {
                     self.line_start = self.point.clone();
 
                     self.account_for_potential_skip();
- 
+
                     #[cfg(feature = "log")]
                     log::debug!("position: after eol: `{:?}`", self.point);
-
                 } else {
                     self.point.column += 1;
                 }
@@ -759,7 +758,6 @@ fn push_impl(
                 };
             }
             State::Retry(name) => {
-
                 #[cfg(feature = "log")]
                 log::debug!("retry:   `{:?}`", name);
 

--- a/src/util/char.rs
+++ b/src/util/char.rs
@@ -115,6 +115,7 @@ pub fn format_opt(char: Option<char>) -> String {
 }
 
 /// Format an optional `byte` (`none` means eof).
+#[cfg(feature = "log")]
 pub fn format_byte_opt(byte: Option<u8>) -> String {
     byte.map_or("end of file".into(), |byte| {
         format!("byte {}", format_byte(byte))
@@ -191,6 +192,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "log")]
     fn test_format_byte_opt() {
         assert_eq!(
             format_byte_opt(None),


### PR DESCRIPTION
Log is unnecessary for production code so this can be turned into optional whilst debugging.

This saves code sizes and dependencies on pre-1.0 crates.

fwiw - there is also tracing may be worth consideration in future