### PR TITLE
Remove `json` from default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "benches/bench.rs"
 harness = false
 
 [features]
-default = ["json"]
+default = []
 json = ["dep:serde", "dep:serde_json"]
 
 [dependencies]


### PR DESCRIPTION
Fixes #47 

json serialization is supplementary feature and ecosystem would assume this would be optional faeture on top of parsing

Aligns to ecosystem re: default primary feature set whilst reducing codesizes & maintenance overhead on-by-default