### PR TITLE
Fix #26 EOF handling in es_whitespace_inside

### DIFF
--- a/src/construct/partial_mdx_jsx.rs
+++ b/src/construct/partial_mdx_jsx.rs
@@ -1070,17 +1070,19 @@ pub fn es_whitespace_inside(tokenizer: &mut Tokenizer) -> State {
             tokenizer.consume();
             State::Next(StateName::MdxJsxEsWhitespaceInside)
         }
-        _ => {
+        Some(_)
             if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-                == CharacterKind::Whitespace
-            {
-                tokenizer.consume();
-                State::Next(StateName::MdxJsxEsWhitespaceInside)
-            } else {
-                tokenizer.exit(Name::MdxJsxEsWhitespace);
-                State::Ok
-            }
+                == CharacterKind::Whitespace =>
+        {
+            tokenizer.consume();
+            State::Next(StateName::MdxJsxEsWhitespaceInside)
         }
+        Some(_) => {
+            tokenizer.exit(Name::MdxJsxEsWhitespace);
+            State::Ok
+        }
+        // Handle EOF.
+        None => State::Nok,
     }
 }
 

--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -117,5 +117,17 @@ fn fuzz() -> Result<(), String> {
         "11: gfm task list items followed by eols (GH-24)"
     );
 
+    assert_eq!(
+        markdown::to_html_with_options(
+            "<",
+            &markdown::Options {
+                parse: markdown::ParseOptions::mdx(),
+                ..Default::default()
+            }
+        ),
+        Ok("<p>&lt;</p>".to_string()),
+        "10: mdx: handle invalid mdx without panic"
+    );
+
     Ok(())
 }

--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -126,7 +126,7 @@ fn fuzz() -> Result<(), String> {
             }
         ),
         Ok("<p>&lt;</p>".to_string()),
-        "10: mdx: handle invalid mdx without panic"
+        "12: mdx: handle invalid mdx without panic (GH-26)"
     );
 
     Ok(())


### PR DESCRIPTION
Since @ChristianMurphy has gone through the trouble of exposing some issues with the parsing, I thought I would try to fix one https://github.com/wooorm/markdown-rs/pull/26. 

While this prevents the program from reaching the `unreachable!` statement
when parsing `"<"`, I do not know if the solution is correct. I do not
completely understand how the parser works and why this issue occurred
and so the solution direction presented in this commit might not be the
best.