### PR TITLE
Fix parsing of nested links

### DIFF
--- a/src/construct/label_end.rs
+++ b/src/construct/label_end.rs
@@ -752,7 +752,7 @@ fn inject_labels(tokenizer: &mut Tokenizer, labels: &[Label]) {
         // Though: if this was what looked like a footnote, but didn’t match,
         // it’s a link instead, and we need to inject the `^`.
         if label.start.1 != label.end.0 || !caret.is_empty() {
-            tokenizer.map.add(
+            tokenizer.map.add_before(
                 label.start.1 + 1,
                 0,
                 vec![Event {

--- a/tests/link_resource.rs
+++ b/tests/link_resource.rs
@@ -1,5 +1,5 @@
 use markdown::{
-    mdast::{Link, Node, Paragraph, Root, Text},
+    mdast::{Image, Link, Node, Paragraph, Root, Text},
     to_html, to_html_with_options, to_mdast,
     unist::Position,
     CompileOptions, Options,
@@ -509,6 +509,28 @@ fn link_resource() -> Result<(), String> {
             position: Some(Position::new(1, 1, 0, 1, 42, 41))
         }),
         "should support link (resource) as `Link`s in mdast"
+    );
+
+    assert_eq!(
+        to_mdast("[![name](image)](url)", &Default::default())?,
+        Node::Root(Root {
+            children: vec![Node::Paragraph(Paragraph {
+                children: vec![Node::Link(Link {
+                    children: vec![Node::Image(Image {
+                        alt: "name".into(),
+                        url: "image".into(),
+                        title: None,
+                        position: Some(Position::new(1, 2, 1, 1, 16, 15)),
+                    }),],
+                    url: "url".into(),
+                    title: None,
+                    position: Some(Position::new(1, 1, 0, 1, 22, 21)),
+                }),],
+                position: Some(Position::new(1, 1, 0, 1, 22, 21)),
+            }),],
+            position: Some(Position::new(1, 1, 0, 1, 22, 21))
+        }),
+        "should support nested links in mdast"
     );
 
     Ok(())


### PR DESCRIPTION
Enter event for LabelText should be inserted before existing events at the index in order to have correct nesting. Otherwise nested elements could have Enter event first and that would result in incorrect nesting in the tree when converting to AST.

Fixes #50