### PR TITLE
Add support for enabling GFM tasklist checkedness

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -831,6 +831,38 @@ pub struct CompileOptions {
     /// ```
     pub gfm_footnote_clobber_prefix: Option<String>,
 
+    /// Whether or not GFM task list html `<input>` items are enabled.
+    ///
+    /// This determines whether or not the user of the browser is able
+    /// to click and toggle generated checkbox items. The default is false.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use markdown::{to_html_with_options, CompileOptions, Options, ParseOptions};
+    /// # fn main() -> Result<(), String> {
+    ///
+    /// // With `gfm_task_list_item_checkable`, generated `<input type="checkbox" />`
+    /// // tags do not contain the attribute `disabled=""` and are thus toggleable by
+    /// // browser users.
+    /// assert_eq!(
+    ///     to_html_with_options(
+    ///         "* [x] y.",
+    ///         &Options {
+    ///             parse: ParseOptions::gfm(),
+    ///             compile: CompileOptions {
+    ///                 gfm_task_list_item_checkable: true,
+    ///                 ..CompileOptions::gfm()
+    ///             }
+    ///         }
+    ///     )?,
+    ///     "<ul>\n<li><input type=\"checkbox\" checked=\"\" /> y.</li>\n</ul>"
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub gfm_task_list_item_checkable: bool,
+
     /// Whether to support the GFM tagfilter.
     ///
     /// This option does nothing if `allow_dangerous_html` is not turned on.

--- a/src/to_html.rs
+++ b/src/to_html.rs
@@ -601,7 +601,10 @@ fn on_enter_gfm_table_row(context: &mut CompileContext) {
 /// Handle [`Enter`][Kind::Enter]:[`GfmTaskListItemCheck`][Name::GfmTaskListItemCheck].
 fn on_enter_gfm_task_list_item_check(context: &mut CompileContext) {
     if !context.image_alt_inside {
-        context.push("<input type=\"checkbox\" disabled=\"\" ");
+        context.push("<input type=\"checkbox\" ");
+        if !context.options.gfm_task_list_item_checkable {
+            context.push("disabled=\"\" ");
+        }
     }
 }
 

--- a/src/util/constant.rs
+++ b/src/util/constant.rs
@@ -2742,7 +2742,7 @@ mod tests {
     fn longest<'a>(list: &[&'a str]) -> Option<&'a str> {
         let mut max = 0;
         let mut result = None;
-        for name in list.iter() {
+        for name in list {
             let len = name.len();
             if len > max {
                 max = len;

--- a/tests/gfm_task_list_item.rs
+++ b/tests/gfm_task_list_item.rs
@@ -2,7 +2,7 @@ use markdown::{
     mdast::{Emphasis, List, ListItem, Node, Paragraph, Root, Text},
     to_html, to_html_with_options, to_mdast,
     unist::Position,
-    Options, ParseOptions,
+    CompileOptions, Options, ParseOptions,
 };
 use pretty_assertions::assert_eq;
 
@@ -24,6 +24,21 @@ fn gfm_task_list_item() -> Result<(), String> {
         to_html_with_options("* [ ] z.", &Options::gfm())?,
         "<ul>\n<li><input type=\"checkbox\" disabled=\"\" /> z.</li>\n</ul>",
         "should support unchecked task list item checks"
+    );
+
+    assert_eq!(
+        to_html_with_options(
+            "* [x] y.",
+            &Options {
+                parse: ParseOptions::gfm(),
+                compile: CompileOptions {
+                    gfm_task_list_item_checkable: true,
+                    ..CompileOptions::gfm()
+                }
+            }
+        )?,
+        "<ul>\n<li><input type=\"checkbox\" checked=\"\" /> y.</li>\n</ul>",
+        "should support option for enabled (checkable) task list item checks"
     );
 
     assert_eq!(


### PR DESCRIPTION
This allows you to to enable whether or not html checkbox inputs are checkable, i.e. do not have the `disable=""` attribute.

Apologies if the terminology is confusing, I felt it was necessary to make it immediately obvious that this doesn't enable/disable checkboxes but instead enables/disables their ability to be checked.