### PR TITLE
Fix `tarpaulin` out format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - run: cargo install cargo-tarpaulin && cargo tarpaulin --out Xml
+      - run: cargo install cargo-tarpaulin && cargo tarpaulin --out xml
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
This change will fix the failure on https://github.com/wooorm/markdown-rs/actions/runs/6252150859/job/16974753952