### PR TITLE
issue 84: GFM strikethrough causes nested attention sequences to be considered just text data

### DIFF
--- a/src/construct/attention.rs
+++ b/src/construct/attention.rs
@@ -236,12 +236,11 @@ fn get_sequences(tokenizer: &mut Tokenizer) -> Vec<Sequence> {
                 let exit = &tokenizer.events[end];
 
                 let marker = tokenizer.parse_state.bytes[enter.point.index];
-                /*
-                    Github has the lovely behavior of not following its own spec.
-                    I've tried a few different markdown parsers and they all will correctly treat
-                    "~" like a punctuation in determining right-flanking delimiter runs.
-                    but github doesn't and it makes their markdown display differently.
-                 */
+
+                // I've tried a few different markdown parsers and they will treat
+                // "~" like a punctuation in determining right-flanking delimiter runs,
+                // but Github doesn't and it makes their markdown display differently.
+                // see tests/gfm_strikethrough.rs -> "e ***~~xxx~~***yyy"
                 let before = if before_index(tokenizer.parse_state.bytes, enter.point.index) == Some('~') {
                     CharacterKind::Other
                 } else {

--- a/src/util/char.rs
+++ b/src/util/char.rs
@@ -64,17 +64,36 @@ pub fn kind_after_index(bytes: &[u8], index: usize) -> Kind {
         Kind::Whitespace
     } else {
         let byte = bytes[index];
-        if byte.is_ascii_whitespace() {
-            Kind::Whitespace
-        } else if byte.is_ascii_punctuation() {
-            Kind::Punctuation
-        } else if byte.is_ascii_alphanumeric() {
-            Kind::Other
-        } else {
+        classify_ascii(byte).unwrap_or_else(|| {
             // Otherwise: seems to be an ASCII control, so it seems to be a
             // non-ASCII `char`.
             classify_opt(after_index(bytes, index))
-        }
+        })
+    }
+}
+
+pub fn kind_before_index(bytes: &[u8], index: usize) -> Kind {
+    if index == 0 {
+        Kind::Whitespace
+    } else {
+        let byte = bytes[index - 1];
+        classify_ascii(byte).unwrap_or_else(|| {
+            // Otherwise: seems to be an ASCII control, so it seems to be a
+            // non-ASCII `char`.
+            classify_opt(before_index(bytes, index))
+        })
+    }
+}
+
+fn classify_ascii(byte: u8) -> Option<Kind> {
+    if byte.is_ascii_whitespace() {
+        Some(Kind::Whitespace)
+    } else if byte.is_ascii_punctuation() {
+        Some(Kind::Punctuation)
+    } else if byte.is_ascii_alphanumeric() {
+        Some(Kind::Other)
+    } else {
+        None
     }
 }
 

--- a/tests/gfm_strikethrough.rs
+++ b/tests/gfm_strikethrough.rs
@@ -68,6 +68,36 @@ fn gfm_strikethrough() -> Result<(), String> {
     );
 
     assert_eq!(
+        to_html_with_options("e ***~~xxx~~***yyy", &Options::gfm())?,
+        "<p>e <em><strong><del>xxx</del></strong></em>yyy</p>",
+        "interplay"
+    );
+
+    assert_eq!(
+        to_html_with_options("~~foo __*a*__~~", &Options::gfm())?,
+        "<p><del>foo <strong><em>a</em></strong></del></p>",
+        "should support emphasis within strong emphasis within strikethrough w/ `*` in `_`"
+    );
+
+    assert_eq!(
+        to_html_with_options("~~foo **_a_**~~", &Options::gfm())?,
+        "<p><del>foo <strong><em>a</em></strong></del></p>",
+        "should support emphasis within strong emphasis within strikethrough w/ `*` in `_`"
+    );
+
+    assert_eq!(
+        to_html_with_options("~~foo _**a**_~~", &Options::gfm())?,
+        "<p><del>foo <em><strong>a</strong></em></del></p>",
+        "should support strong emphasis within emphasis within strikethrough w/ `*` in `_`"
+    );
+
+    assert_eq!(
+        to_html_with_options("~~foo *__a__*~~", &Options::gfm())?,
+        "<p><del>foo <em><strong>a</strong></em></del></p>",
+        "should support strong emphasis within emphasis within strikethrough w/ `*` in `_`"
+    );
+
+    assert_eq!(
         to_html_with_options(
             r###"
 # Balanced


### PR DESCRIPTION
The original issue I was trying to solve was that a markdown line like this `~~foo __*a*__~~` was not correctly parsed because tilde was not being considered punctuation.

After changing that, the interplay between emphasis and strikethrough started failing because to implement how Github flavors it, we must consider tilde _not_ punctuation when deciding if the sequence is the close.  The interplay example is `e ***~~xxx~~***yyy`

I've added a specific exception for tilde with a comment explaining why it is there.