### PR TITLE
Mark mdast lists as spread if any children are spread

### DIFF
--- a/src/to_mdast.rs
+++ b/src/to_mdast.rs
@@ -740,7 +740,7 @@ fn on_enter_link(context: &mut CompileContext) {
 /// Handle [`Enter`][Kind::Enter]:{[`ListOrdered`][Name::ListOrdered],[`ListUnordered`][Name::ListUnordered]}.
 fn on_enter_list(context: &mut CompileContext) {
     let ordered = context.events[context.index].name == Name::ListOrdered;
-    let spread = list_loose(context.events, context.index, false);
+    let spread = list_loose(context.events, context.index, true);
 
     context.tail_push(Node::List(List {
         ordered,

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -616,6 +616,41 @@ fn list() -> Result<(), String> {
     );
 
     assert_eq!(
+        to_mdast("* a\n\n   b", &Default::default())?,
+        Node::Root(Root {
+            children: vec![Node::List(List {
+                ordered: false,
+                spread: true,
+                start: None,
+                children: vec![Node::ListItem(ListItem {
+                    checked: None,
+                    spread: true,
+                    children: vec![
+                        Node::Paragraph(Paragraph {
+                            children: vec![Node::Text(Text {
+                                value: "a".into(),
+                                position: Some(Position::new(1, 3, 2, 1, 4, 3))
+                            }),],
+                            position: Some(Position::new(1, 3, 2, 1, 4, 3))
+                        }),
+                        Node::Paragraph(Paragraph {
+                            children: vec![Node::Text(Text {
+                                value: "b".into(),
+                                position: Some(Position::new(3, 4, 8, 3, 5, 9))
+                            }),],
+                            position: Some(Position::new(3, 3, 7, 3, 5, 9))
+                        })
+                    ],
+                    position: Some(Position::new(1, 1, 0, 3, 5, 9))
+                })],
+                position: Some(Position::new(1, 1, 0, 3, 5, 9))
+            })],
+            position: Some(Position::new(1, 1, 0, 3, 5, 9))
+        }),
+        "should support lists, list items as `List`, `ListItem`s in mdast"
+    );
+
+    assert_eq!(
         to_mdast("3. a\n4. b", &Default::default())?,
         Node::Root(Root {
             children: vec![Node::List(List {
@@ -660,7 +695,7 @@ fn list() -> Result<(), String> {
         Node::Root(Root {
             children: vec![Node::List(List {
                 ordered: false,
-                spread: false,
+                spread: true,
                 start: None,
                 children: vec![
                     Node::ListItem(ListItem {


### PR DESCRIPTION
Firstly, thanks for creating a great library! 🚀 

I ran into what I think is a bug in how `List` nodes are marked as `spread`. The [docs](https://docs.rs/markdown/1.0.0-alpha.16/markdown/mdast/struct.List.html#structfield.spread) say this:

> One or more of its children are separated with a blank line from its siblings (when true), or not (when false).

In my testing this didn't seem to be the case. I'd see a spread `ListItem`, but the parent `List` was still marked as _not_ spread.

I looked into the code, added a failing test, and it seemed like `list_loose` was being called incorrectly (at least based on the docstring). Fixing this made the tests pass. I also fixed one existing test that seemed to be asserting incorrectly.

Hope that makes sense! If I'm missing something here, just let me know.