### PR TITLE
Fix panic on incomplete closing frontmatter fence

### DIFF
--- a/src/construct/document.rs
+++ b/src/construct/document.rs
@@ -565,14 +565,16 @@ fn resolve(tokenizer: &mut Tokenizer) {
                 inject_index = child_index + 1;
             }
 
-            if let Some(mut exits) = tokenizer.tokenize_state.document_exits[line].take() {
-                let mut exit_index = 0;
-                while exit_index < exits.len() {
-                    exits[exit_index].point = point.clone();
-                    exit_index += 1;
-                }
+            if line < tokenizer.tokenize_state.document_exits.len() {
+                if let Some(mut exits) = tokenizer.tokenize_state.document_exits[line].take() {
+                    let mut exit_index = 0;
+                    while exit_index < exits.len() {
+                        exits[exit_index].point = point.clone();
+                        exit_index += 1;
+                    }
 
-                child.map.add(inject_index, 0, exits);
+                    child.map.add(inject_index, 0, exits);
+                }
             }
 
             line += 1;

--- a/tests/frontmatter.rs
+++ b/tests/frontmatter.rs
@@ -62,6 +62,12 @@ fn frontmatter() -> Result<(), message::Message> {
     );
 
     assert_eq!(
+        to_html_with_options("---\n--\n", &frontmatter)?,
+        "<hr />\n<p>--</p>\n",
+        "should not panic if newline after 2 marker closing fence"
+    );
+
+    assert_eq!(
         to_html_with_options("---\n----", &frontmatter)?,
         "<hr />\n<hr />",
         "should not support 4 markers in a closing fence"


### PR DESCRIPTION
This fixes an out-of-range index panic when frontmatter only has two closing dashes e.g.

```md
---
title: Some frontmatter
--

Some other content
```