### PR TITLE
Fix padded code (text) in mdast

### DIFF
--- a/src/to_mdast.rs
+++ b/src/to_mdast.rs
@@ -1081,7 +1081,11 @@ fn on_exit_raw_text(context: &mut CompileContext) -> Result<(), message::Message
     }
 
     let value_bytes = value.as_bytes();
-    if value.len() > 2 && value_bytes[0] == b' ' && value_bytes[value.len() - 1] == b' ' {
+    if value.len() > 2
+        && value_bytes[0] == b' '
+        && value_bytes[value.len() - 1] == b' '
+        && !value_bytes.iter().all(|b| *b == b' ')
+    {
         value.remove(0);
         value.pop();
     }

--- a/src/to_mdast.rs
+++ b/src/to_mdast.rs
@@ -1080,6 +1080,12 @@ fn on_exit_raw_text(context: &mut CompileContext) -> Result<(), message::Message
         }
     }
 
+    let value_bytes = value.as_bytes();
+    if value.len() > 2 && value_bytes[0] == b' ' && value_bytes[value.len() - 1] == b' ' {
+        value.remove(0);
+        value.pop();
+    }
+
     match context.tail_mut() {
         Node::InlineCode(node) => node.value = value,
         Node::InlineMath(node) => node.value = value,

--- a/tests/code_text.rs
+++ b/tests/code_text.rs
@@ -205,5 +205,21 @@ fn code_text() -> Result<(), message::Message> {
         "should support code (text) as `InlineCode`s in mdast"
     );
 
+    assert_eq!(
+        to_mdast("` alpha `", &Default::default())?,
+        //     offsets: 012345678
+        Node::Root(Root {
+            children: vec![Node::Paragraph(Paragraph {
+                children: vec![Node::InlineCode(InlineCode {
+                    value: "alpha".into(),
+                    position: Some(Position::new(1, 1, 0, 1, 10, 9))
+                }),],
+                position: Some(Position::new(1, 1, 0, 1, 10, 9))
+            })],
+            position: Some(Position::new(1, 1, 0, 1, 10, 9))
+        }),
+        "should support code (text) as `InlineCode`s in mdast"
+    );
+
     Ok(())
 }

--- a/tests/code_text.rs
+++ b/tests/code_text.rs
@@ -207,7 +207,7 @@ fn code_text() -> Result<(), message::Message> {
 
     assert_eq!(
         to_mdast("` alpha `", &Default::default())?,
-        //     offsets: 012345678
+        //        012345678 <- offsets
         Node::Root(Root {
             children: vec![Node::Paragraph(Paragraph {
                 children: vec![Node::InlineCode(InlineCode {

--- a/tests/code_text.rs
+++ b/tests/code_text.rs
@@ -206,19 +206,33 @@ fn code_text() -> Result<(), message::Message> {
     );
 
     assert_eq!(
-        to_mdast("` alpha `", &Default::default())?,
-        //        012345678 <- offsets
+        to_mdast("`  alpha `", &Default::default())?,
         Node::Root(Root {
             children: vec![Node::Paragraph(Paragraph {
                 children: vec![Node::InlineCode(InlineCode {
-                    value: "alpha".into(),
-                    position: Some(Position::new(1, 1, 0, 1, 10, 9))
+                    value: " alpha".into(),
+                    position: Some(Position::new(1, 1, 0, 1, 11, 10))
                 }),],
-                position: Some(Position::new(1, 1, 0, 1, 10, 9))
+                position: Some(Position::new(1, 1, 0, 1, 11, 10))
             })],
-            position: Some(Position::new(1, 1, 0, 1, 10, 9))
+            position: Some(Position::new(1, 1, 0, 1, 11, 10))
         }),
-        "should support code (text) as `InlineCode`s in mdast"
+        "should strip one space from each side of `InlineCode` if the value starts and ends with space"
+    );
+
+    assert_eq!(
+        to_mdast("`   `", &Default::default())?,
+        Node::Root(Root {
+            children: vec![Node::Paragraph(Paragraph {
+                children: vec![Node::InlineCode(InlineCode {
+                    value: "   ".into(),
+                    position: Some(Position::new(1, 1, 0, 1, 6, 5))
+                }),],
+                position: Some(Position::new(1, 1, 0, 1, 6, 5))
+            })],
+            position: Some(Position::new(1, 1, 0, 1, 6, 5))
+        }),
+        "should not strip any whitespace if `InlineCode` is all whitespace"
     );
 
     Ok(())


### PR DESCRIPTION
Strip one space from the beginning and end of InlineCode if (a) the value starts and ends with a space and (b) is not all spaces.

From [CommonMark spec section 6.1][1]:

> If the resulting string both begins and ends with a space character, but does not consist entirely of space characters, a single space character is removed from the front and back. 

[1]: https://spec.commonmark.org/0.31.2/#code-spans

Resolves #122