### PR TITLE
Fix parsing of JSX with expression

### DIFF
--- a/src/construct/mdx_expression_flow.rs
+++ b/src/construct/mdx_expression_flow.rs
@@ -150,9 +150,10 @@ pub fn end(tokenizer: &mut Tokenizer) -> State {
         Some(b'<') if tokenizer.parse_state.options.constructs.mdx_jsx_flow => {
             // We can’t just say: fine.
             // Lines of blocks have to be parsed until an eol/eof.
+            tokenizer.tokenize_state.token_1 = Name::MdxJsxFlowTag;
             tokenizer.attempt(
-                State::Next(StateName::MdxExpressionFlowAfter),
-                State::Next(StateName::MdxExpressionFlowNok),
+                State::Next(StateName::MdxJsxFlowAfter),
+                State::Next(StateName::MdxJsxFlowNok),
             );
             State::Retry(StateName::MdxJsxStart)
         }
@@ -169,17 +170,6 @@ pub fn end(tokenizer: &mut Tokenizer) -> State {
             State::Nok
         }
     }
-}
-
-/// At something that wasn’t an MDX expression (flow).
-///
-/// ```markdown
-/// > | {A} x
-///     ^
-/// ```
-pub fn nok(tokenizer: &mut Tokenizer) -> State {
-    reset(tokenizer);
-    State::Nok
 }
 
 /// Reset state.

--- a/src/state.rs
+++ b/src/state.rs
@@ -357,7 +357,6 @@ pub enum Name {
     MdxExpressionFlowBefore,
     MdxExpressionFlowAfter,
     MdxExpressionFlowEnd,
-    MdxExpressionFlowNok,
 
     MdxExpressionStart,
     MdxExpressionBefore,
@@ -844,7 +843,6 @@ pub fn call(tokenizer: &mut Tokenizer, name: Name) -> State {
         Name::MdxExpressionFlowBefore => construct::mdx_expression_flow::before,
         Name::MdxExpressionFlowAfter => construct::mdx_expression_flow::after,
         Name::MdxExpressionFlowEnd => construct::mdx_expression_flow::end,
-        Name::MdxExpressionFlowNok => construct::mdx_expression_flow::nok,
 
         Name::MdxExpressionTextStart => construct::mdx_expression_text::start,
         Name::MdxExpressionTextAfter => construct::mdx_expression_text::after,

--- a/tests/mdx_jsx_text.rs
+++ b/tests/mdx_jsx_text.rs
@@ -1,8 +1,8 @@
 mod test_utils;
 use markdown::{
     mdast::{
-        AttributeContent, AttributeValue, AttributeValueExpression, Emphasis, MdxJsxAttribute,
-        MdxJsxTextElement, Node, Paragraph, Root, Text,
+        AttributeContent, AttributeValue, AttributeValueExpression, Emphasis, MdxFlowExpression,
+        MdxJsxAttribute, MdxJsxFlowElement, MdxJsxTextElement, Node, Paragraph, Root, Text,
     },
     message, to_html_with_options, to_mdast,
     unist::Position,
@@ -46,6 +46,45 @@ fn mdx_jsx_text_core() -> Result<(), message::Message> {
         to_html_with_options("a <b>*b*</b> c.", &mdx)?,
         "<p>a <em>b</em> c.</p>",
         "should support markdown inside elements"
+    );
+
+    assert_eq!(
+        to_mdast("{1}<a/>", &mdx.parse)?,
+        Node::Root(Root {
+            children: vec![
+                Node::MdxFlowExpression(MdxFlowExpression {
+                    value: "1".into(),
+                    position: Some(Position::new(1, 1, 0, 1, 4, 3)),
+                    stops: vec![(0, 1)]
+                }),
+                Node::MdxJsxFlowElement(MdxJsxFlowElement {
+                    name: Some("a".into()),
+                    attributes: vec![],
+                    children: vec![],
+                    position: Some(Position::new(1, 4, 3, 1, 8, 7))
+                })
+            ],
+            position: Some(Position::new(1, 1, 0, 1, 8, 7))
+        }),
+        "should support mdx jsx (text) with expression child"
+    );
+
+    assert_eq!(
+        to_mdast("<a>{1}</a>", &mdx.parse)?,
+        Node::Root(Root {
+            children: vec![Node::MdxJsxFlowElement(MdxJsxFlowElement {
+                name: Some("a".into()),
+                attributes: vec![],
+                children: vec![Node::MdxFlowExpression(MdxFlowExpression {
+                    value: "1".into(),
+                    position: Some(Position::new(1, 4, 3, 1, 7, 6)),
+                    stops: vec![(0, 4)]
+                })],
+                position: Some(Position::new(1, 1, 0, 1, 11, 10))
+            }),],
+            position: Some(Position::new(1, 1, 0, 1, 11, 10))
+        }),
+        "should support mdx jsx (text) with expression child"
     );
 
     assert_eq!(


### PR DESCRIPTION
**Disclaimer:** I am not entirely sure that this is the correct fix, but it does pass the tests. Happy to make changes in the likely case I haven't quite understood this fully.

This fixes the issues mentioned in #136, where this case `<x>{1}</x>` was no longer parsed, and `{1}<x/>` caused a panic when converted into an AST (not an issue when converting to HTML).

I was first confused about what the expected output should be here, so I looked at micromark for inspiration. Here's what I found:

- Micromark parses `<x>{1}</x>` as a block level Flow element with an expression (unlike this crate as of alpha.16, which produced a paragraph with an inline JSX text node)
- Micromark parses `{1}</x>` into an AST with a `root` element, with two children: the expr, and the JSX tag

This change now makes this crate matches micromark's behavior.

<details><summary>Test program I used</summary>

```js
import {mdxjs} from 'micromark-extension-mdxjs'
import {fromMarkdown} from 'mdast-util-from-markdown'
import {mdxFromMarkdown} from 'mdast-util-mdx'


const doc = "<span>{1}</span>";

const tree = fromMarkdown(doc, {
  extensions: [mdxjs()],
  mdastExtensions: [mdxFromMarkdown()]
})


console.log(JSON.stringify(tree, null, 2))
```
</details>

This also removes the `MdxExpressionFlowNok` part of the state, as it wasn't used any more.

Fixes #136 