### PR TITLE
Improve the docs when running cargo docs and fix the Clippy warnings for mdast_util_to_markdown

### DIFF
--- a/mdast_util_to_markdown/src/configure.rs
+++ b/mdast_util_to_markdown/src/configure.rs
@@ -10,7 +10,7 @@ pub struct Options {
     pub emphasis: char,
     /// Marker to use for fenced code `` ` `` or `~`, the default is `` ` ``.
     pub fence: char,
-    /// Whether to use fenced code always (the default is `true`). The default is to use fenced code
+    /// Whether to use fenced code always the default is `true`. The default is to use fenced code
     /// if there is a language defined, if the code is empty, or if it starts or ends in blank lines.
     pub fences: bool,
     /// How to indent the content of list items the default is [`IndentOptions::One`].
@@ -26,8 +26,9 @@ pub struct Options {
     /// Whether to add the same number of number signs `#` at the end of an ATX heading as the
     /// opening sequence the default `false`.
     pub close_atx: bool,
-    /// Whether to always use resource links (bool, default: false). The default is to use autolinks
-    /// `<https://example.com>` when possible and resource links `[text](url)` otherwise.
+    /// Whether to always use resource links the default option is `false`.
+    /// The default is to use autolinks `<https://example.com>` when possible and resource links
+    /// `[text](url)` otherwise.
     pub resource_link: bool,
     /// Whether to add spaces between markers in thematic breaks the default is `false`.
     pub rule_spaces: bool,
@@ -38,14 +39,14 @@ pub struct Options {
     pub setext: bool,
     /// Whether to join definitions without a blank line the default is `false`.
     pub tight_definitions: bool,
-    /// Number of markers to use for thematic breaks the default is `3` and min is `3`.
+    /// Number of markers to use for thematic breaks the default is `3` and the minimum is `3`.
     pub rule_repetition: u32,
 }
 
 #[derive(Copy, Clone)]
 pub enum IndentOptions {
-    /// Depends on the item and its parent list uses 'One' if the item and list are tight and 'Tab'
-    /// otherwise.
+    /// Depends on the item and its parent list uses [`IndentOptions::One`] if the item and list are
+    /// tight and [`IndentOptions::Tab`] otherwise.
     Mixed,
     /// The size of the bullet plus one space.
     One,

--- a/mdast_util_to_markdown/src/configure.rs
+++ b/mdast_util_to_markdown/src/configure.rs
@@ -1,27 +1,27 @@
 pub struct Options {
     /// Marker to use for bullets of items in unordered lists ('*', '+', or '-', default: '*').
     pub bullet: char,
-    // Marker to use in certain cases where the primary bullet doesn’t work
-    // ('*', '+', or '-', default: '-' when bullet is '*', '*' otherwise).
+    /// Marker to use in certain cases where the primary bullet doesn’t work
+    /// ('*', '+', or '-', default: '-' when bullet is '*', '*' otherwise).
     pub bullet_other: char,
     /// Marker to use for bullets of items in ordered lists ('.' or ')', default: '.').
     pub bullet_ordered: char,
     /// Marker to use for emphasis ('*' or '_', default: '*').
     pub emphasis: char,
-    // Marker to use for fenced code ('`' or '~', default: '`').
+    /// Marker to use for fenced code ('`' or '~', default: '`').
     pub fence: char,
     /// Whether to use fenced code always (bool, default: true). The default is to use fenced code
     /// if there is a language defined, if the code is empty, or if it starts or ends in blank lines.
     pub fences: bool,
-    // How to indent the content of list items (default: 'IndentOptions::One').
+    /// How to indent the content of list items (default: 'IndentOptions::One').
     pub list_item_indent: IndentOptions,
     /// Marker to use for titles ('"' or "'", default: '"').
     pub quote: char,
     /// Marker to use for thematic breaks ('*', '-', or '_', default: '*').
     pub rule: char,
-    // Marker to use for strong ('*' or '_', default: '*').
+    /// Marker to use for strong ('*' or '_', default: '*').
     pub strong: char,
-    // Whether to increment the counter of ordered lists items (bool, default: true).
+    /// Whether to increment the counter of ordered lists items (bool, default: true).
     pub increment_list_marker: bool,
     /// Whether to add the same number of number signs (#) at the end of an ATX heading as the
     /// opening sequence (bool, default: false).
@@ -37,16 +37,16 @@ pub struct Options {
     pub setext: bool,
     /// Whether to join definitions without a blank line (bool, default: false).
     pub tight_definitions: bool,
-    // Number of markers to use for thematic breaks (u32, default: 3, min: 3).
+    /// Number of markers to use for thematic breaks (u32, default: 3, min: 3).
     pub rule_repetition: u32,
 }
 
 #[derive(Copy, Clone)]
 pub enum IndentOptions {
-    // Depends on the item and its parent list uses 'One' if the item and list are tight and 'Tab'
-    // otherwise.
+    /// Depends on the item and its parent list uses 'One' if the item and list are tight and 'Tab'
+    /// otherwise.
     Mixed,
-    // The size of the bullet plus one space.
+    /// The size of the bullet plus one space.
     One,
     /// Tab stop.
     Tab,

--- a/mdast_util_to_markdown/src/configure.rs
+++ b/mdast_util_to_markdown/src/configure.rs
@@ -1,43 +1,44 @@
 pub struct Options {
-    /// Marker to use for bullets of items in unordered lists ('*', '+', or '-', default: '*').
+    /// Marker to use for bullets of items in unordered lists `*`, `+`, or `-`, the default is `*`.
     pub bullet: char,
     /// Marker to use in certain cases where the primary bullet doesn’t work
-    /// ('*', '+', or '-', default: '-' when bullet is '*', '*' otherwise).
+    /// `*`, `+`, or `-`, the default is `-` when bullet is `*`, `*` otherwise.
     pub bullet_other: char,
-    /// Marker to use for bullets of items in ordered lists ('.' or ')', default: '.').
+    /// Marker to use for bullets of items in ordered lists `.` or `)`, the default is `.`.
     pub bullet_ordered: char,
-    /// Marker to use for emphasis ('*' or '_', default: '*').
+    /// Marker to use for emphasis `*` or `_`, the default is `*`.
     pub emphasis: char,
-    /// Marker to use for fenced code ('`' or '~', default: '`').
+    /// Marker to use for fenced code `` ` `` or `~`, the default is `` ` ``.
     pub fence: char,
-    /// Whether to use fenced code always (bool, default: true). The default is to use fenced code
+    /// Whether to use fenced code always (the default is `true`). The default is to use fenced code
     /// if there is a language defined, if the code is empty, or if it starts or ends in blank lines.
     pub fences: bool,
-    /// How to indent the content of list items (default: 'IndentOptions::One').
+    /// How to indent the content of list items the default is [`IndentOptions::One`].
     pub list_item_indent: IndentOptions,
-    /// Marker to use for titles ('"' or "'", default: '"').
+    /// Marker to use for titles `"` or `` ` ``, the default is `"`.
     pub quote: char,
-    /// Marker to use for thematic breaks ('*', '-', or '_', default: '*').
+    /// Marker to use for thematic breaks `*`, `-`, or `_`, the default is `*`.
     pub rule: char,
-    /// Marker to use for strong ('*' or '_', default: '*').
+    /// Marker to use for strong `*` or `_`, the default `*`.
     pub strong: char,
-    /// Whether to increment the counter of ordered lists items (bool, default: true).
+    /// Whether to increment the counter of ordered lists items the default is `true`.
     pub increment_list_marker: bool,
-    /// Whether to add the same number of number signs (#) at the end of an ATX heading as the
-    /// opening sequence (bool, default: false).
+    /// Whether to add the same number of number signs `#` at the end of an ATX heading as the
+    /// opening sequence the default `false`.
     pub close_atx: bool,
     /// Whether to always use resource links (bool, default: false). The default is to use autolinks
-    /// (<https://example.com>) when possible and resource links ([text](url)) otherwise.
+    /// `<https://example.com>` when possible and resource links `[text](url)` otherwise.
     pub resource_link: bool,
-    /// Whether to add spaces between markers in thematic breaks (bool, default: false).
+    /// Whether to add spaces between markers in thematic breaks the default is `false`.
     pub rule_spaces: bool,
-    /// Whether to use setext headings when possible (bool, default: false). The default is to always
-    /// use ATX headings (# heading) instead of setext headings (heading\n=======). Setext headings
-    /// cannot be used for empty headings or headings with a rank of three or more.
+    /// Whether to use setext headings when possible the default option is `false`.
+    /// The default is to always use ATX headings `# heading` instead of setext headings
+    /// `heading\n=======`. Setext headings cannot be used for empty headings or headings
+    /// with a rank of three or more.
     pub setext: bool,
-    /// Whether to join definitions without a blank line (bool, default: false).
+    /// Whether to join definitions without a blank line the default is `false`.
     pub tight_definitions: bool,
-    /// Number of markers to use for thematic breaks (u32, default: 3, min: 3).
+    /// Number of markers to use for thematic breaks the default is `3` and min is `3`.
     pub rule_repetition: u32,
 }
 

--- a/mdast_util_to_markdown/src/construct_name.rs
+++ b/mdast_util_to_markdown/src/construct_name.rs
@@ -1,12 +1,12 @@
 #[derive(Clone, PartialEq)]
 pub enum ConstructName {
     ///
-    //// Whole autolink.
-    ////
-    //// ```markdown
-    //// > | <https://example.com> and <admin@example.com>
-    ////     ^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^
-    //// ```
+    /// Whole autolink.
+    ///
+    /// ```markdown
+    /// > | <https://example.com> and <admin@example.com>
+    ///     ^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^
+    /// ```
     Autolink,
     ///
     /// Whole block quote.

--- a/mdast_util_to_markdown/src/util/longest_char_streak.rs
+++ b/mdast_util_to_markdown/src/util/longest_char_streak.rs
@@ -20,7 +20,7 @@ pub fn longest_char_streak(haystack: &str, needle: char) -> usize {
 }
 
 #[cfg(test)]
-mod longest_char_streak {
+mod test {
     use super::*;
 
     #[test]

--- a/mdast_util_to_markdown/tests/roundtrip.rs
+++ b/mdast_util_to_markdown/tests/roundtrip.rs
@@ -122,23 +122,23 @@ fn roundtrip() {
     let step1 = "\\ \\\\ \\\\\\ \\\\\\\\";
     let step2 = "\\ \\ \\\\\\ \\\\\\\\\n";
     assert_eq!(
-        to(&from(&step1, &Default::default()).unwrap()).unwrap(),
+        to(&from(step1, &Default::default()).unwrap()).unwrap(),
         step2
     );
     assert_eq!(
-        to(&from(&step2, &Default::default()).unwrap()).unwrap(),
+        to(&from(step2, &Default::default()).unwrap()).unwrap(),
         step2
     );
 
     let doc = "\\\\\\*a\n";
-    assert_eq!(to(&from(&doc, &Default::default()).unwrap()).unwrap(), doc);
+    assert_eq!(to(&from(doc, &Default::default()).unwrap()).unwrap(), doc);
 
     let doc = "\\\\*a\\\\\\*";
     assert_eq!(
         remove_pos(&mut from(doc, &Default::default()).unwrap()),
         remove_pos(
             &mut from(
-                &to(&from(&doc, &Default::default()).unwrap()).unwrap(),
+                &to(&from(doc, &Default::default()).unwrap()).unwrap(),
                 &Default::default()
             )
             .unwrap()
@@ -146,13 +146,13 @@ fn roundtrip() {
     );
 
     let doc = "```\n	\n```\n";
-    assert_eq!(to(&from(&doc, &Default::default()).unwrap()).unwrap(), doc);
+    assert_eq!(to(&from(doc, &Default::default()).unwrap()).unwrap(), doc);
 
     let doc = "* * -\n";
-    assert_eq!(to(&from(&doc, &Default::default()).unwrap()).unwrap(), doc);
+    assert_eq!(to(&from(doc, &Default::default()).unwrap()).unwrap(), doc);
 
     let doc = "- ***\n";
-    assert_eq!(to(&from(&doc, &Default::default()).unwrap()).unwrap(), doc);
+    assert_eq!(to(&from(doc, &Default::default()).unwrap()).unwrap(), doc);
 
     let mut tree = from("* a\n- b", &Default::default()).unwrap();
     assert_eq!(


### PR DESCRIPTION
This PR is a follow up for #127 to comply with how the docs are written in this project and to fix some of the warnings raised by Clippy when running `cargo clippy --all-features --all-targets --workspace`