### PR TITLE
Fix clippy issues

### DIFF
--- a/src/construct/content.rs
+++ b/src/construct/content.rs
@@ -182,7 +182,7 @@ pub fn resolve(tokenizer: &mut Tokenizer) -> Result<Option<Subresult>, message::
     let result = subtokenize(
         &mut tokenizer.events,
         tokenizer.parse_state,
-        &Some(Content::Content),
+        Some(&Content::Content),
     )?;
 
     Ok(Some(result))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -74,6 +74,6 @@ pub fn parse<'a>(
             return Ok((events, parse_state));
         }
 
-        result = subtokenize(&mut events, &parse_state, &None)?;
+        result = subtokenize(&mut events, &parse_state, None)?;
     }
 }

--- a/src/subtokenize.rs
+++ b/src/subtokenize.rs
@@ -78,7 +78,7 @@ pub fn link_to(events: &mut [Event], previous: usize, next: usize) {
 pub fn subtokenize(
     events: &mut Vec<Event>,
     parse_state: &ParseState,
-    filter: &Option<Content>,
+    filter: Option<&Content>,
 ) -> Result<Subresult, message::Message> {
     let mut map = EditMap::new();
     let mut index = 0;
@@ -97,9 +97,7 @@ pub fn subtokenize(
             debug_assert_eq!(event.kind, Kind::Enter);
 
             // No need to enter linked events again.
-            if link.previous.is_none()
-                && (filter.is_none() || &link.content == filter.as_ref().unwrap())
-            {
+            if link.previous.is_none() && (filter.is_none() || link.content == *filter.unwrap()) {
                 // Index into `events` pointing to a chunk.
                 let mut link_index = Some(index);
                 // Subtokenizer.


### PR DESCRIPTION
With newer versions of Rust and Clippy the CI jobs errors out, this PR fixes the errors raised by Clippy to make the CI pass.

