### PR TITLE
Allow data URIs as image sources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -285,7 +285,7 @@ The following bash scripts are useful when working on this project:
 The typical security aspect discussed for markdown is [cross-site scripting
 (XSS)][xss] attacks.
 Markdown itself is safe if it does not include embedded HTML or dangerous
-protocols in links/images (such as `javascript:` or `data:`).
+protocols in links/images (such as `javascript:`).
 `markdown-rs` makes any markdown safe by default, even if HTML is embedded or
 dangerous protocols are used, as it encodes or drops them.
 Turning on the `allow_dangerous_html` or `allow_dangerous_protocol` options for

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -518,9 +518,9 @@ pub struct CompileOptions {
     ///
     /// URLs that have no protocol (which means it’s relative to the current
     /// page, such as `./some/page.html`) and URLs that have a safe protocol
-    /// (for images: `http`, `https`; for links: `http`, `https`, `irc`,
+    /// (for images: `http`, `https`, `data`; for links: `http`, `https`, `irc`,
     /// `ircs`, `mailto`, `xmpp`), are safe.
-    /// All other URLs are dangerous and dropped.
+    /// All other URLs are considered dangerous by this library and dropped.
     ///
     /// ## Examples
     ///

--- a/src/util/constant.rs
+++ b/src/util/constant.rs
@@ -274,7 +274,7 @@ pub const SAFE_PROTOCOL_HREF: [&str; 6] = ["http", "https", "irc", "ircs", "mail
 /// List of protocols allowed, when operating safely, as `src` on `img`.
 ///
 /// This list is based on what is allowed by GitHub.
-pub const SAFE_PROTOCOL_SRC: [&str; 2] = ["http", "https"];
+pub const SAFE_PROTOCOL_SRC: [&str; 3] = ["http", "https", "data"];
 
 /// The number of characters that form a tab stop.
 ///

--- a/tests/misc_dangerous_protocol.rs
+++ b/tests/misc_dangerous_protocol.rs
@@ -113,6 +113,12 @@ fn dangerous_protocol_image() {
         "<p><img src=\"a/b:c\" alt=\"\" /></p>",
         "should allow a colon in a path"
     );
+
+    assert_eq!(
+        to_html("![](data:image/png;base64,abc)"),
+        "<p><img src=\"data:image/png;base64,abc\" alt=\"\" /></p>",
+        "should allow data URIs"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Data URIs allow embedding image data directly within HTML documents using the `src` attribute of `<img>` tags. This practice is generally safe and does not lead to arbitrary code execution. 

I understand this is a scary pull request to merge when one is not familiar with the topic, so here is a detailed explanation:

1. **Image Rendering Context**: When a Data URI is used in an `<img>` tag, browsers interpret and render the content strictly as an image. They do not execute any embedded scripts or code within this context. 
  - https://developer.mozilla.org/en-US/docs/Web/SVG/SVG_as_an_Image#restrictions
  - https://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html#SVG_image

2. **SVG Restrictions**: SVGs can contain scripts, all browsers impose security restrictions. SVG images embedded via `<img>` tags have scripting disabled, preventing any embedded JavaScript from executing.

Using Data URIs within `<img>` tags is a secure method for embedding images directly into HTML documents. Browsers handle these URIs in a way that prevents code execution. 


Other markdown rendering libraries, including the one used by github (comrak), do not consider image data URLs as unsafe.

Example:

```rust
use comrak::*;

fn main() {

let mut options = Options::default();
let input = "
![](http://example.com)
![](data:image/png,aaa)
![](javascript:dangerous)
";

println!("{}", markdown_to_html(input, &options));
}
```

Results in

```html
<p><img src="http://example.com" alt="" />
<img src="data:image/png,aaa" alt="" />
<img src="" alt="" /></p>
```


fixes https://github.com/wooorm/markdown-rs/issues/163